### PR TITLE
Adapt retry behavior

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -27,6 +27,8 @@ jobs:
           MERGE_FILTER_AUTHOR: "dependabot[bot]"
           MERGE_LABELS: "dependencies"
           MERGE_METHOD: "rebase"
+          MERGE_RETRIES: 4
+          MERGE_RETRY_SLEEP: 120_000
           UPDATE_LABELS: "disable_updating"
         name: automerge
         uses: "pascalgn/automerge-action@v0.15.6"


### PR DESCRIPTION
The default retry behavior is too aggressive and causes the action to give up before the Maven build is done